### PR TITLE
Fix saved position for reminder frame

### DIFF
--- a/reminder_frame/reminder_core.lua
+++ b/reminder_frame/reminder_core.lua
@@ -44,11 +44,13 @@ function ReminderCore:CreateOrUpdateFrame()
     if WorkoutBuddy.ReminderFrame then return end -- Already created
     WorkoutBuddy:DbgPrint("ReminderCore: Creating Frame")
 
-    local opts = ReminderState.getProfileOpts()  -- FIX: define opts
+    local opts = ReminderState.getProfileOpts()
 
     WorkoutBuddy.ReminderFrame = CreateFrame("Frame", "WorkoutBuddy_ReminderFrame", UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
     WorkoutBuddy.ReminderFrame:SetSize(320, 140)
-    WorkoutBuddy.ReminderFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
+    local x = opts.x or ReminderState.DEFAULTS.x
+    local y = opts.y or ReminderState.DEFAULTS.y
+    WorkoutBuddy.ReminderFrame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", x, y)
     WorkoutBuddy.ReminderFrame:SetScale(opts.scale or 1.1)
     WorkoutBuddy.ReminderFrame:SetAlpha(opts.alpha or 0.85)
     WorkoutBuddy.ReminderFrame:SetMovable(true)


### PR DESCRIPTION
## Summary
- use stored frame coordinates when creating the reminder frame

## Testing
- `luac -p reminder_frame/reminder_core.lua`
- `find . -name '*.lua' -not -path './Libs/*' -print0 | xargs -0 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_683f8223981c832e8d385df9f1716efa