### PR TITLE
Add stats tracking and UI

### DIFF
--- a/WorkoutBuddy.lua
+++ b/WorkoutBuddy.lua
@@ -20,6 +20,7 @@ local defaults = {
             zonechange_zone = false,
             zonechange_indoors = false,
         },
+        stats = {},
     }
 }
 

--- a/WorkoutBuddy.toc
+++ b/WorkoutBuddy.toc
@@ -23,6 +23,7 @@ Libs\LibDBIcon-1.0\embeds.xml
 
 WorkoutBuddy.lua
 events.lua
+stats.lua
 
 reminder_frame/reminder_state.lua
 reminder_frame/reminder_queue.lua
@@ -33,6 +34,7 @@ reminder_frame.lua
 config\workout_library.lua
 config\general.lua
 config\workouts.lua
+config\stats.lua
 config\importexport.lua
 config\profile.lua
 config.lua

--- a/config.lua
+++ b/config.lua
@@ -10,6 +10,7 @@ function WorkoutBuddy:InitConfig()
         args = {
             general      = WorkoutBuddy_GeneralTab(),
             workouts     = WorkoutBuddy_WorkoutsTab(),
+            stats        = WorkoutBuddy_StatsTab(),
             importexport = WorkoutBuddy_ImportExportTab(),
             profile      = WorkoutBuddy_ProfileTab and WorkoutBuddy_ProfileTab() or AceDBOptions:GetOptionsTable(WorkoutBuddy.db),
         },

--- a/config/stats.lua
+++ b/config/stats.lua
@@ -1,0 +1,40 @@
+local AceConfig = LibStub("AceConfig-3.0")
+local AceConfigDialog = LibStub("AceConfigDialog-3.0")
+
+function WorkoutBuddy_StatsTab()
+    return {
+        type = "group",
+        name = "Stats",
+        order = 4,
+        args = {
+            timeframe = {
+                type = "select",
+                name = "Time Frame",
+                order = 1,
+                values = {
+                    lifetime = "Lifetime",
+                    week = "This Week",
+                    month = "This Month",
+                },
+                get = function()
+                    return WorkoutBuddy._statsTimeframe or "lifetime"
+                end,
+                set = function(info, val)
+                    WorkoutBuddy._statsTimeframe = val
+                    LibStub("AceConfigRegistry-3.0"):NotifyChange("WorkoutBuddy")
+                end,
+            },
+            summary = {
+                type = "description",
+                name = function()
+                    local tf = WorkoutBuddy._statsTimeframe or "lifetime"
+                    if WorkoutBuddy.Stats and WorkoutBuddy.Stats.GetSummary then
+                        return WorkoutBuddy.Stats:GetSummary(tf)
+                    end
+                    return "No data"
+                end,
+                order = 2,
+            },
+        },
+    }
+end

--- a/reminder_frame/reminder_core.lua
+++ b/reminder_frame/reminder_core.lua
@@ -201,8 +201,8 @@ function ReminderCore:UpdateDisplay()
         btnComplete:SetPoint("LEFT", label, "RIGHT", 4, 0)
         btnComplete:SetNormalTexture("Interface\\Buttons\\UI-CheckBox-Check")
         btnComplete:SetScript("OnClick", function()
-            ReminderQueue:RemoveAt(i)
-            ReminderCore:UpdateDisplay()
+            ReminderCore.currentIndex = i
+            ReminderCore:HandleComplete()
         end)
         SetTooltip(btnComplete, "Mark as complete")
 
@@ -212,6 +212,7 @@ function ReminderCore:UpdateDisplay()
         btnPartial:SetPoint("LEFT", btnComplete, "RIGHT", 2, 0)
         btnPartial:SetNormalTexture("Interface\\Buttons\\UI-RefreshButton")
         btnPartial:SetScript("OnClick", function()
+            ReminderCore.currentIndex = i
             ReminderCore:ShowPartialInput(i, workout)
         end)
         SetTooltip(btnPartial, "Partial complete")
@@ -267,6 +268,9 @@ function ReminderCore:ShowPartialInput(index, workout)
     edit:SetText("")
     edit:SetScript("OnEnterPressed", function()
         local amt = tonumber(edit:GetText()) or 0
+        if amt > 0 and WorkoutBuddy.Stats and WorkoutBuddy.Stats.AddRecord then
+            WorkoutBuddy.Stats:AddRecord(workout.name, amt, workout.unit, true)
+        end
         ReminderQueue:SubtractAmount(index, amt)
         box:Hide()
         ReminderCore:UpdateDisplay()
@@ -278,6 +282,9 @@ function ReminderCore:ShowPartialInput(index, workout)
     ok:SetText("OK")
     ok:SetScript("OnClick", function()
         local amt = tonumber(edit:GetText()) or 0
+        if amt > 0 and WorkoutBuddy.Stats and WorkoutBuddy.Stats.AddRecord then
+            WorkoutBuddy.Stats:AddRecord(workout.name, amt, workout.unit, true)
+        end
         ReminderQueue:SubtractAmount(index, amt)
         box:Hide()
         ReminderCore:UpdateDisplay()
@@ -303,6 +310,10 @@ function ReminderCore:HandleComplete()
     local idx = ReminderCore.currentIndex or 1
     local queue = ReminderState.getQueue()
     if queue[idx] then
+        local workout = queue[idx]
+        if WorkoutBuddy.Stats and WorkoutBuddy.Stats.AddRecord then
+            WorkoutBuddy.Stats:AddRecord(workout.name, workout.amount, workout.unit, false)
+        end
         ReminderQueue:RemoveAt(idx)
         ReminderCore:UpdateDisplay()
     end
@@ -314,6 +325,10 @@ function ReminderCore:HandlePartial()
     if queue[idx] then
         local amt = tonumber(WorkoutBuddy.ReminderFrame.inputPartial:GetText()) or 0
         if amt > 0 then
+            local workout = queue[idx]
+            if WorkoutBuddy.Stats and WorkoutBuddy.Stats.AddRecord then
+                WorkoutBuddy.Stats:AddRecord(workout.name, amt, workout.unit, true)
+            end
             ReminderQueue:SubtractAmount(idx, amt)
             ReminderCore:UpdateDisplay()
         end

--- a/stats.lua
+++ b/stats.lua
@@ -1,0 +1,66 @@
+local WorkoutBuddy = WorkoutBuddy
+
+local Stats = {}
+
+local function timeNow()
+    return (GetServerTime and GetServerTime()) or os.time()
+end
+
+function Stats:AddRecord(name, amount, unit, partial)
+    if not WorkoutBuddy.db or not WorkoutBuddy.db.profile then return end
+    WorkoutBuddy.db.profile.stats = WorkoutBuddy.db.profile.stats or {}
+    table.insert(WorkoutBuddy.db.profile.stats, {
+        activity = name,
+        amount = amount,
+        unit = unit,
+        partial = partial,
+        timestamp = timeNow(),
+    })
+    local reg = LibStub and LibStub("AceConfigRegistry-3.0", true)
+    if reg then reg:NotifyChange("WorkoutBuddy") end
+end
+
+function Stats:GetRecords()
+    if not WorkoutBuddy.db or not WorkoutBuddy.db.profile then return {} end
+    return WorkoutBuddy.db.profile.stats or {}
+end
+
+local function filterRecords(records, timeframe)
+    if timeframe == "lifetime" then return records end
+    local now = timeNow()
+    local start
+    if timeframe == "week" then
+        start = now - 7*86400
+    elseif timeframe == "month" then
+        local d = date("!*t", now)
+        d.day, d.hour, d.min, d.sec = 1,0,0,0
+        start = time(d)
+    else
+        return records
+    end
+    local out = {}
+    for _,r in ipairs(records) do
+        if (r.timestamp or 0) >= start then
+            table.insert(out, r)
+        end
+    end
+    return out
+end
+
+function Stats:GetSummary(timeframe)
+    local recs = filterRecords(self:GetRecords(), timeframe)
+    local total = 0
+    local byActivity = {}
+    for _,r in ipairs(recs) do
+        total = total + 1
+        byActivity[r.activity] = (byActivity[r.activity] or 0) + 1
+    end
+    local lines = { string.format("Total Activities: %d", total) }
+    for act,count in pairs(byActivity) do
+        table.insert(lines, string.format("%s: %d", act, count))
+    end
+    return table.concat(lines, "\n")
+end
+
+WorkoutBuddy.Stats = Stats
+return Stats


### PR DESCRIPTION
## Summary
- track completed/partial workouts in saved variables
- show Stats tab with timeframe filter
- hook stats tracking into reminder actions
- update addon manifest
- refresh stats display when new entries are added

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f9989c72c832e88b5ec7fb5ace54a