### PR TITLE
Improve stats summary and timeframe options

### DIFF
--- a/config/stats.lua
+++ b/config/stats.lua
@@ -13,8 +13,10 @@ function WorkoutBuddy_StatsTab()
                 order = 1,
                 values = {
                     lifetime = "Lifetime",
+                    day = "Today",
                     week = "This Week",
                     month = "This Month",
+                    custom = "Custom",
                 },
                 get = function()
                     return WorkoutBuddy._statsTimeframe or "lifetime"
@@ -24,16 +26,35 @@ function WorkoutBuddy_StatsTab()
                     LibStub("AceConfigRegistry-3.0"):NotifyChange("WorkoutBuddy")
                 end,
             },
+            customInput = {
+                type = "input",
+                name = "Custom Range",
+                desc = "Use '5d' for 5 days or '2w' for 2 weeks",
+                order = 2,
+                hidden = function()
+                    return (WorkoutBuddy._statsTimeframe or "lifetime") ~= "custom"
+                end,
+                get = function()
+                    return WorkoutBuddy._statsCustomInput or ""
+                end,
+                set = function(info, val)
+                    WorkoutBuddy._statsCustomInput = val
+                    LibStub("AceConfigRegistry-3.0"):NotifyChange("WorkoutBuddy")
+                end,
+            },
             summary = {
                 type = "description",
                 name = function()
                     local tf = WorkoutBuddy._statsTimeframe or "lifetime"
+                    if tf == "custom" then
+                        tf = WorkoutBuddy._statsCustomInput or "lifetime"
+                    end
                     if WorkoutBuddy.Stats and WorkoutBuddy.Stats.GetSummary then
                         return WorkoutBuddy.Stats:GetSummary(tf)
                     end
                     return "No data"
                 end,
-                order = 2,
+                order = 3,
             },
         },
     }

--- a/stats.lua
+++ b/stats.lua
@@ -4,8 +4,8 @@ local Stats = {}
 
 local function timeNow()
 
-    -- Use WoW API if available, otherwise fall back to Lua's time()
-    return (GetServerTime and GetServerTime()) or time()
+    -- Use WoW API if available, otherwise fall back to Lua's os.time()
+    return (GetServerTime and GetServerTime()) or os.time()
 end
 
 function Stats:AddRecord(name, amount, unit, partial)
@@ -29,20 +29,36 @@ function Stats:GetRecords()
 end
 
 local function filterRecords(records, timeframe)
-    if timeframe == "lifetime" then return records end
+    if timeframe == "lifetime" or not timeframe then return records end
+
     local now = timeNow()
     local start
-    if timeframe == "week" then
-        start = now - 7*86400
+
+    if timeframe == "day" then
+        start = now - 86400
+    elseif timeframe == "week" then
+        start = now - 7 * 86400
     elseif timeframe == "month" then
         local d = date("!*t", now)
-        d.day, d.hour, d.min, d.sec = 1,0,0,0
+        d.day, d.hour, d.min, d.sec = 1, 0, 0, 0
         start = time(d)
     else
-        return records
+        -- Allow custom strings like '5d' or '2w'
+        local num, unit = timeframe:match("^(%d+)%s*([dw])$")
+        num = tonumber(num)
+        if num and unit then
+            if unit == "d" then
+                start = now - num * 86400
+            elseif unit == "w" then
+                start = now - num * 7 * 86400
+            end
+        end
     end
+
+    if not start then return records end
+
     local out = {}
-    for _,r in ipairs(records) do
+    for _, r in ipairs(records) do
         if (r.timestamp or 0) >= start then
             table.insert(out, r)
         end
@@ -54,14 +70,23 @@ function Stats:GetSummary(timeframe)
     local recs = filterRecords(self:GetRecords(), timeframe)
     local total = 0
     local byActivity = {}
-    for _,r in ipairs(recs) do
+
+    for _, r in ipairs(recs) do
         total = total + 1
-        byActivity[r.activity] = (byActivity[r.activity] or 0) + 1
+        local key = r.activity
+        byActivity[key] = byActivity[key] or { amount = 0, unit = r.unit }
+        byActivity[key].amount = byActivity[key].amount + (r.amount or 0)
+        if r.unit and r.unit ~= "" then
+            byActivity[key].unit = r.unit
+        end
     end
-    local lines = { string.format("Total Activities: %d", total) }
-    for act,count in pairs(byActivity) do
-        table.insert(lines, string.format("%s: %d", act, count))
+
+    local lines = { string.format("Total Workouts: %d", total) }
+    for act, info in pairs(byActivity) do
+        local unitStr = info.unit and info.unit ~= "" and (" " .. info.unit) or ""
+        table.insert(lines, string.format("%s: %d%s", act, info.amount, unitStr))
     end
+
     return table.concat(lines, "\n")
 end
 


### PR DESCRIPTION
## Summary
- enhance stats summary to show total amounts per activity
- support custom timeframe parsing including days/weeks
- expose new timeframe options (Today & Custom) with input field

## Testing
- `luac -p *.lua config/*.lua reminder_frame/*.lua`
- manual Lua test to verify summary output

------
https://chatgpt.com/codex/tasks/task_e_683faddba8bc832ea0ec14e8ca8b1cf2