### PR TITLE
Fix hydration popup position persistence

### DIFF
--- a/WorkoutBuddy.lua
+++ b/WorkoutBuddy.lua
@@ -46,6 +46,18 @@ local defaults = {
             next_time = 0,
             last_time = 0,
         },
+        -- Reminder frame settings (position, scaling, etc.)
+        reminder_frame = {
+            x = 400,
+            y = -200,
+            scale = 1.1,
+            alpha = 0.85,
+            show_when = "rested",
+            sound = 567463,
+            autocenter = true,
+        },
+        -- Stored queue of pending workouts
+        reminder_queue = {},
     }
 }
 
@@ -110,7 +122,10 @@ function WorkoutBuddy:OnProfileChanged()
         WorkoutBuddy.ReminderCore:OnProfileChanged()
     end
 
-    if WorkoutBuddy.Hydration and WorkoutBuddy.Hydration.Resume then
+    if WorkoutBuddy.Hydration and WorkoutBuddy.Hydration.OnProfileChanged then
+        WorkoutBuddy.Hydration:OnProfileChanged()
+    elseif WorkoutBuddy.Hydration and WorkoutBuddy.Hydration.Resume then
+        -- Fallback for older versions
         WorkoutBuddy.Hydration:Resume()
     end
 end

--- a/hydration.lua
+++ b/hydration.lua
@@ -147,6 +147,22 @@ function Hydration:Resume()
     self.timer = C_Timer.NewTimer(delay, function() Hydration:OnTimer() end)
 end
 
+-- Reapply profile settings when the active profile changes
+function Hydration:OnProfileChanged()
+    local o = opts()
+    if self.frame then
+        self.frame:ClearAllPoints()
+        self.frame:SetPoint("CENTER", UIParent, "CENTER", o.x or 0, o.y or 0)
+        self.frame:SetScale(o.scale or 1)
+        self.frame:SetAlpha(o.alpha or 0.9)
+    end
+    if o.enabled then
+        self:Resume()
+    else
+        self:Stop()
+    end
+end
+
 if WorkoutBuddy then
     WorkoutBuddy.Hydration = Hydration
 else

--- a/reminder_frame/reminder_core.lua
+++ b/reminder_frame/reminder_core.lua
@@ -380,6 +380,27 @@ function ReminderCore:DebugAddTest()
     ReminderCore:UpdateDisplay()
 end
 
+-- Apply current profile options to an existing frame
+function ReminderCore:ApplyOptions()
+    if not WorkoutBuddy.ReminderFrame then return end
+    local opts = ReminderState.getProfileOpts()
+    local x = opts.x or ReminderState.DEFAULTS.x
+    local y = opts.y or ReminderState.DEFAULTS.y
+    WorkoutBuddy.ReminderFrame:ClearAllPoints()
+    WorkoutBuddy.ReminderFrame:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", x, y)
+    WorkoutBuddy.ReminderFrame:SetScale(opts.scale or ReminderState.DEFAULTS.scale)
+    WorkoutBuddy.ReminderFrame:SetAlpha(opts.alpha or ReminderState.DEFAULTS.alpha)
+end
+
+-- Called when AceDB profile changes or reloads
+function ReminderCore:OnProfileChanged()
+    if not WorkoutBuddy.ReminderFrame then
+        self:CreateOrUpdateFrame()
+    end
+    self:ApplyOptions()
+    self:UpdateDisplay()
+end
+
 --------------------------------------------------------
 -- Initialization
 --------------------------------------------------------


### PR DESCRIPTION
## Summary
- add default saved data for reminder frame and queue
- refresh hydration and reminder frames when the profile changes
- provide API for applying reminder frame options

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd6494590832e80507383a1cbeac3