### PR TITLE
Fix hydration frame persistence and initial reminder frame position

### DIFF
--- a/WorkoutBuddy.lua
+++ b/WorkoutBuddy.lua
@@ -49,7 +49,7 @@ local defaults = {
         -- Reminder frame settings (position, scaling, etc.)
         reminder_frame = {
             x = 400,
-            y = -200,
+            y = 500,
             scale = 1.1,
             alpha = 0.85,
             show_when = "rested",

--- a/hydration.lua
+++ b/hydration.lua
@@ -41,14 +41,20 @@ function Hydration:GetInterval()
     return ((o.timeframe or 120) * 60) / reminders
 end
 
-function Hydration:CreateFrame()
-    if self.frame then return end
+function Hydration:ApplyOptions()
+    if not self.frame then return end
     local o = opts()
-    self.frame = CreateFrame("Frame", "WorkoutBuddy_HydrationFrame", UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
-    self.frame:SetSize(220, 80)
+    self.frame:ClearAllPoints()
     self.frame:SetPoint("CENTER", UIParent, "CENTER", o.x or 0, o.y or 0)
     self.frame:SetScale(o.scale or 1)
     self.frame:SetAlpha(o.alpha or 0.9)
+end
+
+function Hydration:CreateFrame()
+    if self.frame then return end
+    self.frame = CreateFrame("Frame", "WorkoutBuddy_HydrationFrame", UIParent, BackdropTemplateMixin and "BackdropTemplate" or nil)
+    self.frame:SetSize(220, 80)
+    self:ApplyOptions()
     self.frame:SetBackdrop({
         bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background-Dark",
         edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
@@ -63,7 +69,8 @@ function Hydration:CreateFrame()
     self.frame:SetScript("OnDragStop", function(f)
         f:StopMovingOrSizing()
         local _, _, _, xOfs, yOfs = f:GetPoint()
-        o.x, o.y = math.floor(xOfs + 0.5), math.floor(yOfs + 0.5)
+        local opt = opts()
+        opt.x, opt.y = math.floor(xOfs + 0.5), math.floor(yOfs + 0.5)
     end)
 
     self.frame.text = self.frame:CreateFontString(nil, "OVERLAY", "GameFontHighlightLarge")
@@ -88,9 +95,8 @@ end
 
 function Hydration:ShowPopup(test)
     self:CreateFrame()
+    self:ApplyOptions()
     local o = opts()
-    self.frame:SetScale(o.scale or 1)
-    self.frame:SetAlpha(o.alpha or 0.9)
     local msg
     if o.mode == "interval" then
         msg = "Time to drink water!"
@@ -150,12 +156,8 @@ end
 -- Reapply profile settings when the active profile changes
 function Hydration:OnProfileChanged()
     local o = opts()
-    if self.frame then
-        self.frame:ClearAllPoints()
-        self.frame:SetPoint("CENTER", UIParent, "CENTER", o.x or 0, o.y or 0)
-        self.frame:SetScale(o.scale or 1)
-        self.frame:SetAlpha(o.alpha or 0.9)
-    end
+    self:CreateFrame()
+    self:ApplyOptions()
     if o.enabled then
         self:Resume()
     else

--- a/reminder_frame/reminder_state.lua
+++ b/reminder_frame/reminder_state.lua
@@ -3,7 +3,7 @@ WorkoutBuddy:DbgPrint("Loaded: reminder_state.lua")
 local PROFILE_KEY = "reminder_frame"
 local QUEUE_KEY = "reminder_queue"
 local DEFAULTS = {
-    x = 400, y = -200, scale = 1.1, alpha = 0.85,
+    x = 400, y = 500, scale = 1.1, alpha = 0.85,
     show_when = "rested", sound = 567463,
     autocenter = true,
 }


### PR DESCRIPTION
## Summary
- ensure hydration popup uses stored profile options and updates its location correctly
- adjust default reminder frame coordinates so new profiles start on-screen

## Testing
- `luac` was not available so basic Lua compilation couldn't be run

------
https://chatgpt.com/codex/tasks/task_e_683fdb992828832eab8777e66ed670a7