### PR TITLE
Add configurable auto-open events

### DIFF
--- a/WorkoutBuddy.lua
+++ b/WorkoutBuddy.lua
@@ -57,6 +57,12 @@ local defaults = {
             autocenter = true,
             initialized = false,
         },
+        -- When to automatically open the reminder frame
+        reminder_events = {
+            taxi = true,
+            rested = true,
+            quest = true,
+        },
         -- Stored queue of pending workouts
         reminder_queue = {},
     }
@@ -140,6 +146,10 @@ function WorkoutBuddy:OnProfileChanged()
     end
     self:RebuildWorkoutListOptions()
     self:ForceFullConfigRefresh()
+
+    if WorkoutBuddy.ReminderEvents and WorkoutBuddy.ReminderEvents.Register then
+        WorkoutBuddy.ReminderEvents:Register()
+    end
 
     if WorkoutBuddy.ReminderCore and WorkoutBuddy.ReminderCore.OnProfileChanged then
         WorkoutBuddy.ReminderCore:OnProfileChanged()

--- a/config/general.lua
+++ b/config/general.lua
@@ -102,6 +102,64 @@ function WorkoutBuddy_GeneralTab()
                     },
                 },
             },
+            openEventsHeader = {
+                type = "header",
+                name = "Auto-Open Events",
+                order = 6,
+            },
+            openEvents = {
+                type = "group",
+                name = "Open Reminder Frame Automatically",
+                inline = true,
+                order = 7,
+                args = {
+                    taxi = {
+                        type = "toggle",
+                        name = "On Flight Path",
+                        desc = "Show the reminder frame while on a taxi if workouts are queued.",
+                        order = 1,
+                        get = function()
+                            return WorkoutBuddy.db and WorkoutBuddy.db.profile.reminder_events and WorkoutBuddy.db.profile.reminder_events.taxi or false
+                        end,
+                        set = function(info, val)
+                            WorkoutBuddy.db.profile.reminder_events.taxi = val
+                            if WorkoutBuddy.ReminderEvents and WorkoutBuddy.ReminderEvents.Register then
+                                WorkoutBuddy.ReminderEvents:Register()
+                            end
+                        end,
+                    },
+                    rested = {
+                        type = "toggle",
+                        name = "When Rested",
+                        desc = "Show the reminder frame when becoming rested and workouts are queued.",
+                        order = 2,
+                        get = function()
+                            return WorkoutBuddy.db and WorkoutBuddy.db.profile.reminder_events and WorkoutBuddy.db.profile.reminder_events.rested or false
+                        end,
+                        set = function(info, val)
+                            WorkoutBuddy.db.profile.reminder_events.rested = val
+                            if WorkoutBuddy.ReminderEvents and WorkoutBuddy.ReminderEvents.Register then
+                                WorkoutBuddy.ReminderEvents:Register()
+                            end
+                        end,
+                    },
+                    quest = {
+                        type = "toggle",
+                        name = "Quest Turn-in",
+                        desc = "Show the reminder frame after turning in a quest if workouts are queued.",
+                        order = 3,
+                        get = function()
+                            return WorkoutBuddy.db and WorkoutBuddy.db.profile.reminder_events and WorkoutBuddy.db.profile.reminder_events.quest or false
+                        end,
+                        set = function(info, val)
+                            WorkoutBuddy.db.profile.reminder_events.quest = val
+                            if WorkoutBuddy.ReminderEvents and WorkoutBuddy.ReminderEvents.Register then
+                                WorkoutBuddy.ReminderEvents:Register()
+                            end
+                        end,
+                    },
+                },
+            },
         },
     }
 end


### PR DESCRIPTION
## Summary
- allow configuring when the reminder frame auto-opens
- add UI toggles for taxi, rested and quest turn-in events
- only auto-open if there are workouts queued
- re-register reminder events on profile changes

## Testing
- `git status --short`
- `luajit` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_6840de58d960832e85d09055b48862b7