### PR TITLE
Add open-empty option for auto-open events

### DIFF
--- a/WorkoutBuddy.lua
+++ b/WorkoutBuddy.lua
@@ -89,6 +89,7 @@ local defaults = {
             taxi = true,
             rested = true,
             quest = true,
+            open_empty = false,
         },
         -- Stored queue of pending workouts
         reminder_queue = {},

--- a/config/general.lua
+++ b/config/general.lua
@@ -184,6 +184,22 @@ function WorkoutBuddy_GeneralTab()
                             end
                         end,
                     }),
+                    open_empty = EventBox(4, {
+                        type = "toggle",
+                        name = "Open When No Activities",
+                        desc = "Also show the reminder frame when the queue is empty.",
+                        width = "full",
+                        order = 1,
+                        get = function()
+                            return WorkoutBuddy.db and WorkoutBuddy.db.profile.reminder_events and WorkoutBuddy.db.profile.reminder_events.open_empty or false
+                        end,
+                        set = function(info, val)
+                            WorkoutBuddy.db.profile.reminder_events.open_empty = val
+                            if WorkoutBuddy.ReminderEvents and WorkoutBuddy.ReminderEvents.Register then
+                                WorkoutBuddy.ReminderEvents:Register()
+                            end
+                        end,
+                    }),
                     -- custom open triggers inserted dynamically
                 },
             },

--- a/trigger_manager.lua
+++ b/trigger_manager.lua
@@ -8,6 +8,16 @@ reminder frame).
 
 local TriggerManager = {}
 
+-- Helper to see if any workouts are queued
+local function QueueHasItems()
+    local q = WorkoutBuddy.ReminderState and WorkoutBuddy.ReminderState.getQueue()
+    return q and #q > 0
+end
+local function QueueIsEmpty()
+    local q = WorkoutBuddy.ReminderState and WorkoutBuddy.ReminderState.getQueue()
+    return not q or #q == 0
+end
+
 -- Build the event list from the wow_events.lua file
 TriggerManager.EventList = { CUSTOM = "Custom Event" }
 if WorkoutBuddy_WowEvents then
@@ -99,7 +109,9 @@ function TriggerManager:HandleEvent(event, ...)
             end
             if pass then
                 if t.action == "open_frame" then
-                    if WorkoutBuddy.ReminderCore and WorkoutBuddy.ReminderCore.ShowIfAllowed then
+                    local openEmpty = WorkoutBuddy.db and WorkoutBuddy.db.profile and WorkoutBuddy.db.profile.reminder_events and WorkoutBuddy.db.profile.reminder_events.open_empty
+                    local hasItems = QueueHasItems()
+                    if WorkoutBuddy.ReminderCore and WorkoutBuddy.ReminderCore.ShowIfAllowed and (hasItems or (openEmpty and QueueIsEmpty())) then
                         WorkoutBuddy.ReminderCore:ShowIfAllowed()
                     end
                 else


### PR DESCRIPTION
## Summary
- add `open_empty` default to saved variables
- expose a new "Open When No Activities" toggle under auto-open events
- update reminder event logic to support opening the frame when the queue is empty
- apply the same logic to custom `open_frame` triggers

## Testing
- `luac -p WorkoutBuddy.lua`
- `luac -p config/general.lua`
- `luac -p reminder_frame/reminder_events.lua`
- `luac -p trigger_manager.lua`


------
https://chatgpt.com/codex/tasks/task_e_68421f0c0ec4832ea474d7af632852b6