### PR TITLE
Add display tab for frame settings

### DIFF
--- a/WorkoutBuddy.toc
+++ b/WorkoutBuddy.toc
@@ -41,6 +41,7 @@ config\general.lua
 config\automation.lua
 config\workouts.lua
 config\hydration.lua
+config\display.lua
 config\stats.lua
 config\importexport.lua
 config\profile.lua

--- a/config.lua
+++ b/config.lua
@@ -22,9 +22,9 @@ function WorkoutBuddy:InitConfig()
         type = "group",
         args = {
             general      = WorkoutBuddy_GeneralTab(),
+            display      = WorkoutBuddy_DisplayTab(),
             workouts     = WorkoutBuddy_WorkoutsTab(),
             hydration    = WorkoutBuddy_HydrationTab(),
-            display      = WorkoutBuddy_DisplayTab(),
             stats        = WorkoutBuddy_StatsTab(),
             importexport = WorkoutBuddy_ImportExportTab(),
             profile      = WorkoutBuddy_ProfileTab and WorkoutBuddy_ProfileTab() or AceDBOptions:GetOptionsTable(WorkoutBuddy.db),

--- a/config.lua
+++ b/config.lua
@@ -24,6 +24,7 @@ function WorkoutBuddy:InitConfig()
             general      = WorkoutBuddy_GeneralTab(),
             workouts     = WorkoutBuddy_WorkoutsTab(),
             hydration    = WorkoutBuddy_HydrationTab(),
+            display      = WorkoutBuddy_DisplayTab(),
             stats        = WorkoutBuddy_StatsTab(),
             importexport = WorkoutBuddy_ImportExportTab(),
             profile      = WorkoutBuddy_ProfileTab and WorkoutBuddy_ProfileTab() or AceDBOptions:GetOptionsTable(WorkoutBuddy.db),

--- a/config/display.lua
+++ b/config/display.lua
@@ -5,7 +5,7 @@ function WorkoutBuddy_DisplayTab()
     return {
         type = "group",
         name = "Display",
-        order = 6,
+        order = 2,
         args = {
             reminderHeader = {
                 type = "header",
@@ -47,6 +47,7 @@ function WorkoutBuddy_DisplayTab()
                         name = "Scale",
                         min = 0.5, max = 2, step = 0.05,
                         order = 1,
+                        width = "full",
                         get = function() return WorkoutBuddy.db.profile.hydration.scale or 1 end,
                         set = function(info, val)
                             WorkoutBuddy.db.profile.hydration.scale = val
@@ -60,6 +61,7 @@ function WorkoutBuddy_DisplayTab()
                         name = "Opacity",
                         min = 0.2, max = 1, step = 0.05,
                         order = 2,
+                        width = "full",
                         get = function() return WorkoutBuddy.db.profile.hydration.alpha or 0.9 end,
                         set = function(info, val)
                             WorkoutBuddy.db.profile.hydration.alpha = val
@@ -72,6 +74,7 @@ function WorkoutBuddy_DisplayTab()
                         type = "execute",
                         name = "Center Frame",
                         order = 3,
+                        width = "full",
                         func = function() WorkoutBuddy.Hydration:CenterFrame(true) end,
                     },
                 },

--- a/config/display.lua
+++ b/config/display.lua
@@ -1,0 +1,82 @@
+local AceConfig = LibStub("AceConfig-3.0")
+local AceConfigDialog = LibStub("AceConfigDialog-3.0")
+
+function WorkoutBuddy_DisplayTab()
+    return {
+        type = "group",
+        name = "Display",
+        order = 6,
+        args = {
+            reminderHeader = {
+                type = "header",
+                name = "Workout Reminder Frame",
+                order = 1,
+            },
+            reminderOptions = {
+                type = "group",
+                name = "Workout Reminder Frame Options",
+                inline = true,
+                order = 2,
+                args = {
+                    centerNow = {
+                        type = "execute",
+                        name = "Center Frame Now",
+                        width = "full",
+                        order = 1,
+                        func = function()
+                            if WorkoutBuddy.ReminderCore and WorkoutBuddy.ReminderCore.CenterFrame then
+                                WorkoutBuddy.ReminderCore:CenterFrame(true)
+                            end
+                        end,
+                    },
+                },
+            },
+            hydrationHeader = {
+                type = "header",
+                name = "Hydration Popup",
+                order = 3,
+            },
+            hydrationOptions = {
+                type = "group",
+                name = "Hydration Frame Options",
+                inline = true,
+                order = 4,
+                args = {
+                    scale = {
+                        type = "range",
+                        name = "Scale",
+                        min = 0.5, max = 2, step = 0.05,
+                        order = 1,
+                        get = function() return WorkoutBuddy.db.profile.hydration.scale or 1 end,
+                        set = function(info, val)
+                            WorkoutBuddy.db.profile.hydration.scale = val
+                            if WorkoutBuddy.Hydration.frame then
+                                WorkoutBuddy.Hydration.frame:SetScale(val)
+                            end
+                        end,
+                    },
+                    alpha = {
+                        type = "range",
+                        name = "Opacity",
+                        min = 0.2, max = 1, step = 0.05,
+                        order = 2,
+                        get = function() return WorkoutBuddy.db.profile.hydration.alpha or 0.9 end,
+                        set = function(info, val)
+                            WorkoutBuddy.db.profile.hydration.alpha = val
+                            if WorkoutBuddy.Hydration.frame then
+                                WorkoutBuddy.Hydration.frame:SetAlpha(val)
+                            end
+                        end,
+                    },
+                    center = {
+                        type = "execute",
+                        name = "Center Frame",
+                        order = 3,
+                        func = function() WorkoutBuddy.Hydration:CenterFrame(true) end,
+                    },
+                },
+            },
+        },
+    }
+end
+

--- a/config/general.lua
+++ b/config/general.lua
@@ -89,30 +89,6 @@ function WorkoutBuddy_GeneralTab()
                 order = 3.5,
                 func = function() WorkoutBuddy:OpenTriggerEditor("workout") end,
             },
-            frameHeader = {
-                type = "header",
-                name = "Reminder Frame",
-                order = 4,
-            },
-            frameOptions = {
-                type = "group",
-                name = "Workout Reminder Frame Options",
-                inline = true,
-                order = 5,
-                args = {
-                    centerNow = {
-                        type = "execute",
-                        name = "Center Frame Now",
-                        width = "full",
-                        order = 2,
-                        func = function()
-                            if WorkoutBuddy.ReminderCore and WorkoutBuddy.ReminderCore.CenterFrame then
-                                WorkoutBuddy.ReminderCore:CenterFrame(true)
-                            end
-                        end,
-                    },
-                },
-            },
             openEventsHeader = {
                 type = "header",
                 name = "Auto-Open Events",

--- a/config/hydration.lua
+++ b/config/hydration.lua
@@ -125,43 +125,6 @@ function WorkoutBuddy_HydrationTab()
                 order = 6,
                 func = function() WorkoutBuddy.Hydration:ShowPopup(true) end,
             },
-            frameHeader = {
-                type = "header",
-                name = "Frame Options",
-                order = 7,
-            },
-            scale = {
-                type = "range",
-                name = "Scale",
-                min = 0.5, max = 2, step = 0.05,
-                order = 8,
-                get = function() return WorkoutBuddy.db.profile.hydration.scale or 1 end,
-                set = function(info, val)
-                    WorkoutBuddy.db.profile.hydration.scale = val
-                    if WorkoutBuddy.Hydration.frame then
-                        WorkoutBuddy.Hydration.frame:SetScale(val)
-                    end
-                end,
-            },
-            alpha = {
-                type = "range",
-                name = "Opacity",
-                min = 0.2, max = 1, step = 0.05,
-                order = 9,
-                get = function() return WorkoutBuddy.db.profile.hydration.alpha or 0.9 end,
-                set = function(info, val)
-                    WorkoutBuddy.db.profile.hydration.alpha = val
-                    if WorkoutBuddy.Hydration.frame then
-                        WorkoutBuddy.Hydration.frame:SetAlpha(val)
-                    end
-                end,
-            },
-            center = {
-                type = "execute",
-                name = "Center Frame",
-                order = 10,
-                func = function() WorkoutBuddy.Hydration:CenterFrame(true) end,
-            },
         },
     }
 end

--- a/config/hydration.lua
+++ b/config/hydration.lua
@@ -13,7 +13,7 @@ function WorkoutBuddy_HydrationTab()
     return {
         type = "group",
         name = "Hydration",
-        order = 5,
+        order = 4,
         args = {
             enable = {
                 type = "toggle",

--- a/config/importexport.lua
+++ b/config/importexport.lua
@@ -6,7 +6,7 @@ function WorkoutBuddy_ImportExportTab()
     return {
         type = "group",
         name = "Import/Export",
-        order = 3,
+        order = 6,
         args = {
             importExportHeader = {
                 type = "header",

--- a/config/stats.lua
+++ b/config/stats.lua
@@ -5,7 +5,7 @@ function WorkoutBuddy_StatsTab()
     return {
         type = "group",
         name = "Stats",
-        order = 4,
+        order = 5,
         args = {
             timeframe = {
                 type = "select",

--- a/config/workouts.lua
+++ b/config/workouts.lua
@@ -18,7 +18,7 @@ function WorkoutBuddy_WorkoutsTab()
     return {
         type = "group",
         name = "Workouts",
-        order = 2,
+        order = 3,
         args = {
             workoutListHeader = {
                 type = "header",


### PR DESCRIPTION
## Summary
- add new display tab for adjusting reminder and hydration frame appearance
- move hydration frame options into new display tab
- move reminder frame centering option to the display tab
- wire up display tab in config and toc

## Testing
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422b0cf9cc832ea3fd339faf606d62